### PR TITLE
New function: find_nodes_by_name

### DIFF
--- a/btlib.c
+++ b/btlib.c
@@ -9376,6 +9376,24 @@ int clconnectxx(int ndevice)
 
 /************* SERVICES ******************/
 
+int find_nodes_by_name(const char *name, int *nodes_buf, int buflen)
+{
+	int n;
+	int found_cnt = 0;
+
+	if (nodes_buf == NULL) return -1;
+	if (buflen <= 0) return -2;
+
+	for (n = 0; devok(n) != 0 && found_cnt < (buflen-1); ++n) {
+		if (strcmp(dev[n]->name, name) == 0) {
+			nodes_buf[found_cnt] = dev[n]->node;
+			found_cnt += 1;
+		}
+	}
+	nodes_buf[found_cnt] = 0;
+	return found_cnt;
+}
+
 int find_channel(int node,int flag,unsigned char *uuid)
   {
   int flags,retval,ndevice;

--- a/btlib.h
+++ b/btlib.h
@@ -99,6 +99,7 @@ char *device_name(int node);
 int device_type(int node);
 int disconnect_node(int node);
 
+int find_nodes_by_name(const char *name, int *nodes_buf, int buflen);
 int find_channel(int node,int flag,unsigned char *uuid);
 int find_ctics(int node);
 int find_ctic_index(int node,int flag,unsigned char *uuid);


### PR DESCRIPTION
This function aims to provide users with a better way to connect to their devices by their names.

Currently the library only supports connecting to Bluetooth devices by a given node ID. This ID is set by the library when performing a scan for devices and also by parsing a text file with pre-set device information when calling the init_blue() function.

The problem is that right now users can only see which ID was allocated to the scanned devices by printing in the stdout. With this new function users can call it to find out which IDs were allocated to devices with a given name and don't relying on the stdout. This way users can write more autonomous applications.

Here is a quick example of the function in use:
![image](https://github.com/LaCETI-CIn/btferret/assets/31019638/556049ab-60e3-4a2c-88da-8736cd894590)

the functions takes as input a name, a buffer to store the found IDs, and the buffer size.
It returns the amount of devices found with that name or a negative value in case of error.
It will also add a null terminator (0 in this case) to the buffer.